### PR TITLE
リレーションの誤字修正

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
-  has_many :event_participants, dependent: :estrict_with_errordes
-  has_many :attendances, dependent: :estrict_with_errordes
+  has_many :event_participants, dependent: :restrict_with_error
+  has_many :attendances, dependent: :restrict_with_error
   has_many :talk_themes, dependent: :destroy
   belongs_to :users
 end


### PR DESCRIPTION
## Issue/PR
- #26 
## description
dependentの`estrict_with_errordes`を`restrict_with_error`に修正