### PR TITLE
ダッシュボードにイベント出席機能を追加

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,0 +1,28 @@
+class AttendancesController < ApplicationController
+  before_action :set_event
+
+  def create
+    @attendance = @event.attendances.new(user: current_user, attended_on: Date.today)
+    if @attendance.save
+      redirect_to dashboard_path(current_user), notice: '出席登録が完了しました。'
+    else
+      redirect_to dashboard_path(current_user), alert: '出席登録に失敗しました。'
+    end
+  end
+
+  def destroy
+    @attendance = @event.attendances.find_by(user: current_user)
+    if @attendance
+      @attendance.destroy
+      redirect_to dashboard_path(current_user), notice: '出席を取り消しました。'
+    else
+      redirect_to dashboard_path(current_user), alert: '出席取り消しに失敗しました。'
+    end
+  end
+
+  private
+
+  def set_event
+    @event = Event.find(params[:event_id])
+  end
+end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AttendancesController < ApplicationController
   before_action :set_event
 

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -4,11 +4,11 @@ class AttendancesController < ApplicationController
   before_action :set_event
 
   def create
-    @attendance = @event.attendances.new(user: current_user, attended_on: Date.today)
+    @attendance = @event.attendances.new(user: current_user, attended_on: Time.zone.today)
     if @attendance.save
-      redirect_to dashboard_path(current_user), notice: '出席登録が完了しました。'
+      redirect_to dashboard_path(current_user), notice: t('notice.attendance.create_success')
     else
-      redirect_to dashboard_path(current_user), alert: '出席登録に失敗しました。'
+      redirect_to dashboard_path(current_user), alert: t('alert.attendance.create_failure')
     end
   end
 
@@ -16,9 +16,9 @@ class AttendancesController < ApplicationController
     @attendance = @event.attendances.find_by(user: current_user)
     if @attendance
       @attendance.destroy
-      redirect_to dashboard_path(current_user), notice: '出席を取り消しました。'
+      redirect_to dashboard_path(current_user), notice: t('notice.attendance.destroy_success')
     else
-      redirect_to dashboard_path(current_user), alert: '出席取り消しに失敗しました。'
+      redirect_to dashboard_path(current_user), alert: t('alert.attendance.destroy_failure')
     end
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,6 +4,11 @@ class DashboardController < ApplicationController
   before_action :set_beginning_of_week
   def show
     @user = User.find(params[:user_id])
+    @attendances = @user.attendances.pluck(:attended_on)
+    @attended_events = @user.attendances.includes(:event).where.not(attended_on: nil)
+    @attended_users = @attended_events.map(&:event).flat_map do |event|
+      event.attendances.includes(:user).where.not(attended_on: nil).map(&:user)
+    end.uniq
   end
 
   private

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,17 +4,34 @@ class DashboardController < ApplicationController
   before_action :set_beginning_of_week
   def show
     @user = User.find(params[:user_id])
-    @attendances = @user.attendances.pluck(:attended_on)
-    @attended_events = @user.attendances.includes(:event).where.not(attended_on: nil)
-    @upcoming_attendances = @user.attendances.includes(:event).where(attended_on: Time.zone.today..)
+    @attendances = user_attendances(@user)
+    @attended_events = attended_events(@user)
+    @upcoming_attendances = upcoming_attendances(@user)
+    @attended_users = attended_users(@upcoming_attendances)
+  end
 
-    @attended_users = if @upcoming_attendances.any?
-                        @upcoming_attendances.map(&:event).flat_map do |event|
-                          event.attendances.includes(:user).where(attended_on: Time.zone.today..).map(&:user)
-                        end.uniq
-                      else
-                        []
-                      end
+  private
+
+  def user_attendances(user)
+    user.attendances.pluck(:attended_on)
+  end
+
+  def attended_events(user)
+    user.attendances.includes(:event).where.not(attended_on: nil)
+  end
+
+  def upcoming_attendances(user)
+    user.attendances.includes(:event).where(attended_on: Time.zone.today..)
+  end
+
+  def attended_users(upcoming_attendances)
+    if upcoming_attendances.any?
+      upcoming_attendances.map(&:event).flat_map do |event|
+        event.attendances.includes(:user).where(attended_on: Time.zone.today..).map(&:user)
+      end.uniq
+    else
+      []
+    end
   end
 
   private

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,9 +6,15 @@ class DashboardController < ApplicationController
     @user = User.find(params[:user_id])
     @attendances = @user.attendances.pluck(:attended_on)
     @attended_events = @user.attendances.includes(:event).where.not(attended_on: nil)
-    @attended_users = @attended_events.map(&:event).flat_map do |event|
-      event.attendances.includes(:user).where.not(attended_on: nil).map(&:user)
-    end.uniq
+    @upcoming_attendances = @user.attendances.includes(:event).where(attended_on: Time.zone.today..)
+
+    @attended_users = if @upcoming_attendances.any?
+                        @upcoming_attendances.map(&:event).flat_map do |event|
+                          event.attendances.includes(:user).where(attended_on: Time.zone.today..).map(&:user)
+                        end.uniq
+                      else
+                        []
+                      end
   end
 
   private

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -10,8 +10,6 @@ class DashboardController < ApplicationController
     @attended_users = attended_users(@upcoming_attendances)
   end
 
-  private
-
   def user_attendances(user)
     user.attendances.pluck(:attended_on)
   end

--- a/app/helpers/attendance_helper.rb
+++ b/app/helpers/attendance_helper.rb
@@ -1,0 +1,2 @@
+module AttendanceHelper
+end

--- a/app/helpers/attendance_helper.rb
+++ b/app/helpers/attendance_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module AttendanceHelper
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -2,11 +2,10 @@
 // present in this directory. You're encouraged to place your actual application logic in
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
+import "../toggle-menu.js"
 import "@hotwired/turbo-rails"
 import jQuery from "jquery";
 window.$ = window.jQuery = jQuery;
-
-import "../toggle-menu.js"
 
 require('@rails/ujs').start()
 require('turbolinks').start()

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,6 @@ class User < ApplicationRecord
   end
 
   def attendance_for(event)
-    attendances.find_by(event: event)
+    attendances.find_by(event:)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,13 @@ class User < ApplicationRecord
   def last_attendance_date
     attendances.order(attended_on: :desc).pick(:attended_on)
   end
+
+  def upcoming_event
+    event_ids = event_participants.pluck(:event_id)
+    Event.where(id: event_ids).where('start_time > ?', Time.current).order(:start_time).first
+  end
+
+  def attendance_for(event)
+    attendances.find_by(event: event)
+  end
 end

--- a/app/views/dashboard/show.html.slim
+++ b/app/views/dashboard/show.html.slim
@@ -8,30 +8,36 @@
       = date.day
       - if @attended_events.any? { |attendance| attendance.event.start_time.to_date == date }
         | 💮
-  .upcoming-event
+  .event-attendance
     | 次回のイベント
-    - upcoming_event = @user.upcoming_event
-    - if upcoming_event.present?
-      .event-title
-        = upcoming_event.title
-      .event-start_time
-        = upcoming_event.start_time
-      .attendance
-        - attendance = current_user.attendance_for(upcoming_event)
-        - if attendance
-          | 出席登録済みです
-          = button_to '出席取り消し', event_attendance_path(upcoming_event.id, attendance.id), method: :delete, class: 'btn btn-danger'
-        - else
-          | 出席登録をしてください
-          = button_to '出席登録', event_attendances_path(upcoming_event.id), method: :post, class: 'btn btn-success'
-      .attemded-users
-        | 参加者 (#{@attended_users.count}人)
-        - if @attended_users.any?
-          ul
-            - @attended_users.each do |user|
-              li
-                = link_to user_path(user) do
-                  img src= user.avatar_url
-                  = user.name
-        - else
-          | 現在、参加しているユーザーはいません。
+    .upcoming-event
+      - upcoming_event = @user.upcoming_event
+      - if @user.event_participants.empty?
+        | 参加登録しているイベントがありません！
+        | 参加するイベントを探してみませんか？
+        = link_to 'イベント一覧' , events_path
+      - else
+        - if upcoming_event.present?
+          .event-title
+            = upcoming_event.title
+          .event-start_time
+            = upcoming_event.start_time
+          .attendance
+            - attendance = current_user.attendance_for(upcoming_event)
+            - if attendance
+              | 出席登録済みです
+              = button_to '出席取り消し', event_attendance_path(upcoming_event.id, attendance.id), method: :delete, class: 'btn btn-danger'
+            - else
+              | 出席登録をしてください
+              = button_to '出席登録', event_attendances_path(upcoming_event.id), method: :post, class: 'btn btn-success'    
+        .attemded-users
+          | 参加者 (#{@attended_users.count}人)
+          - if @attended_users.any?
+            ul
+              - @attended_users.each do |user|
+                li
+                  = link_to user_path(user) do
+                    img src= user.avatar_url
+                    = user.name
+          - else
+            | 現在、参加しているユーザーはいません。

--- a/app/views/dashboard/show.html.slim
+++ b/app/views/dashboard/show.html.slim
@@ -2,7 +2,35 @@
   .user-name.flex.items-center.text-2xl
     = link_to user_path(@user) do
       img src=@user.avatar_url alt="User Icon" class="w-10 h-10 rounded-full mr-2"
-    = @user.name
+        = @user.name
   .calendar
     = month_calendar do |date|
       = date.day
+      - if @attendances.include?(date)
+        | 💮
+  .upcoming-event
+    | 次回のイベント
+    - upcoming_event = @user.upcoming_event
+    - if upcoming_event.present?
+      .event-title
+        = upcoming_event.title
+      .event-start_time
+        = upcoming_event.start_time
+      .attendance
+        - attendance = current_user.attendance_for(upcoming_event)
+        - if attendance
+          | 出席登録済みです
+          = button_to '出席取り消し', event_attendance_path(upcoming_event.id, attendance.id), method: :delete, class: 'btn btn-danger'
+        - else
+          | 出席登録をしてください
+          = button_to '出席登録', event_attendances_path(upcoming_event.id), method: :post, class: 'btn btn-success'
+      .attemded-users
+        | 参加者 (#{@attended_users.count}人)
+        - if @attended_users.any?
+          ul
+            - @attended_users.each do |user|
+              li
+                img src= @user.avatar_url
+                = link_to user.name, user_path(user)
+        - else
+        | 現在、参加しているユーザーはいません。

--- a/app/views/dashboard/show.html.slim
+++ b/app/views/dashboard/show.html.slim
@@ -6,7 +6,7 @@
   .calendar
     = month_calendar do |date|
       = date.day
-      - if @attendances.include?(date)
+      - if @attended_events.any? { |attendance| attendance.event.start_time.to_date == date }
         | 💮
   .upcoming-event
     | 次回のイベント
@@ -30,7 +30,8 @@
           ul
             - @attended_users.each do |user|
               li
-                img src= @user.avatar_url
-                = link_to user.name, user_path(user)
+                = link_to user_path(user) do
+                  img src= user.avatar_url
+                  = user.name
         - else
-        | 現在、参加しているユーザーはいません。
+          | 現在、参加しているユーザーはいません。

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -11,5 +11,5 @@
     | 最後に参加した日: 
     = @user.last_attendance_date ? @user.last_attendance_date.strftime('%Y年%m月%d日(%a)') : 'まだ参加していません'
 
-
-= link_to "edit", edit_user_path
+  - if current_user == @user
+    = link_to "edit", edit_user_path

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,18 +1,26 @@
 ja:
   notice:
-    user_name_update: 'ユーザー名が更新されました。'
-    user_logout: 'ログアウトしました。'
-    user_name_update: ユーザー名が更新されました。
-  alert:
-    user_not_found: ユーザーが見つかりません。
-  event:
-    notice:
+    user:
+      user_name_update: ユーザー名が更新されました。
+      user_logout: ログアウトしました。
+      user_name_update: ユーザー名が更新されました。
+    event:
       entry_sucsess: イベントへの参加登録が完了しました。
       entry_cancel: イベントへの参加を取り消しました。
       create_sucsess: イベントが作成されました。
       update_sucsess: イベントを更新しました。
       request_deletion: 削除申請を受け付けました。確認次第、削除対応を行います。ありがとうございました。
-    alert:
+    attendance:
+      create_success: 出席登録が完了しました。
+      destroy_success: 出席を取り消しました。
+
+  alert:
+    user:
+      user_not_found: ユーザーが見つかりません。
+    event:
       entry_failure: イベントへの参加登録に失敗しました。
       entry_cancel_failure: イベントへの参加取り消しに失敗しました。
       request_deletion_failure: 削除申請に失敗しました。
+    attendance:
+      create_failure: 出席登録に失敗しました。
+      destroy_failure: 出席取り消しに失敗しました。

--- a/test/controllers/attendance_controller_test.rb
+++ b/test/controllers/attendance_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AttendanceControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## issue・PR

- #46

## description

- メソッドを追加
ユーザーが参加登録している直近のイベントを取得、出席登録しているユーザーを取得するなどのメソッドを追加
- ダッシュボードから参加登録しているイベントへの出席機能を実装
参加登録している直近のイベントへの参加ボタンを設置