### PR TITLE
トークテーマページを追加

### DIFF
--- a/app/controllers/talk_themes_controller.rb
+++ b/app/controllers/talk_themes_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TalkThemesController < ApplicationController
   before_action :set_event
   before_action :check_participation, only: [:create]
@@ -10,7 +12,7 @@ class TalkThemesController < ApplicationController
     @talk_theme = @event.talk_themes.new(talk_theme_params)
     @talk_theme.user_id = current_user.id
     if @talk_theme.save
-      redirect_to event_talk_themes_path(@event), notice: 'トークテーマが追加されました。'
+      redirect_to event_talk_themes_path(@event), notice: t('notice.talk_theme.create_success')
     else
       render :index
     end
@@ -19,7 +21,7 @@ class TalkThemesController < ApplicationController
   def destroy
     @talk_theme = @event.talk_themes.find(params[:id])
     @talk_theme.destroy
-    redirect_to event_talk_themes_path(@event), notice: 'トークテーマが削除されました。'
+    redirect_to event_talk_themes_path(@event), notice: t('notice.talk_theme.destroy_success')
   end
 
   private
@@ -35,6 +37,6 @@ class TalkThemesController < ApplicationController
   def check_participation
     return if @event.event_participants.exists?(user_id: current_user.id)
 
-    redirect_to @event, alert: 'このイベントに参加していないため、トークテーマを登録できません。'
+    redirect_to @event, alert: t('alert.talk_theme.not_participating')
   end
 end

--- a/app/controllers/talk_themes_controller.rb
+++ b/app/controllers/talk_themes_controller.rb
@@ -1,0 +1,40 @@
+class TalkThemesController < ApplicationController
+  before_action :set_event
+  before_action :check_participation, only: [:create]
+
+  def index
+    @talk_themes = @event.talk_themes
+  end
+
+  def create
+    @talk_theme = @event.talk_themes.new(talk_theme_params)
+    @talk_theme.user_id = current_user.id
+    if @talk_theme.save
+      redirect_to event_talk_themes_path(@event), notice: 'トークテーマが追加されました。'
+    else
+      render :index
+    end
+  end
+
+  def destroy
+    @talk_theme = @event.talk_themes.find(params[:id])
+    @talk_theme.destroy
+    redirect_to event_talk_themes_path(@event), notice: 'トークテーマが削除されました。'
+  end
+
+  private
+
+  def set_event
+    @event = Event.find(params[:event_id])
+  end
+
+  def talk_theme_params
+    params.require(:talk_theme).permit(:theme)
+  end
+
+  def check_participation
+    return if @event.event_participants.exists?(user_id: current_user.id)
+
+    redirect_to @event, alert: 'このイベントに参加していないため、トークテーマを登録できません。'
+  end
+end

--- a/app/helpers/talk_themes_helper.rb
+++ b/app/helpers/talk_themes_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module TalkThemesHelper
 end

--- a/app/helpers/talk_themes_helper.rb
+++ b/app/helpers/talk_themes_helper.rb
@@ -1,0 +1,2 @@
+module TalkThemesHelper
+end

--- a/app/views/events/show.html.slim
+++ b/app/views/events/show.html.slim
@@ -6,6 +6,8 @@ header.page-header
   .border-t-2
 
 .page-main
+  .talk-theme-path
+      = link_to "トークテーマ", event_talk_themes_path(@event)
   .container.mx-auto.py-6
     .event-details
       - if @event.status == 'deleted'
@@ -56,4 +58,4 @@ header.page-header
         = link_to '編集する', edit_event_path(@event), class: 'mt-4 px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600 transition-colors'
       .event-deletion-request.mt-6
         = button_to '削除申請', request_deletion_event_path(@event), method: :post, class: 'mt-4 px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition-colors', data: { confirm: '削除申請をしますか？' }
-    = link_to 'イベント一覧', events_path, class: 'block mt-6 text-blue-500 hover:underline'
+      = link_to 'イベント一覧', events_path, class: 'block mt-6 text-blue-500 hover:underline'

--- a/app/views/talk_themes/index.html.slim
+++ b/app/views/talk_themes/index.html.slim
@@ -1,17 +1,19 @@
-h1 トークテーマ一覧
-.talk-theme-form
-  = form_with(model: [@event, TalkTheme.new], local: true) do |f|
-    .add-theme
-      = f.label :theme, "トークテーマ名"
-      = f.text_field :theme
-    = f.submit "追加"
-.talk-themes
- ul
-  - @talk_themes.each do |talk_theme|
-    li
-      .talk-theme
-        = talk_theme.theme
-        - if talk_theme.user_id == current_user.id
-          = button_to '削除', event_talk_theme_path(@event, talk_theme), method: :delete, data: { confirm: '本当に削除しますか？' }
-          
-
+.page-main
+  .max-w-2xl.mx-auto.bg-white.shadow-md.p-6.rounded-lg
+    h1.text-2xl.font-bold.mb-4 トークテーマ一覧
+    .talk-theme-form.mb-6
+      = form_with(model: [@event, TalkTheme.new], local: true) do |f|
+        .add-theme.flex.items-center.mb-4
+          = f.label :theme, "トークテーマ名", class: "block text-lg font-medium text-gray-700 mr-2"
+          = f.text_field :theme, class: "flex-1 border border-gray-300 rounded-md p-2"
+          = f.submit "追加", class: "ml-2 px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600"
+    .talk-themes
+      ul.list-none
+        - @talk_themes.each_with_index do |talk_theme, index|
+          li.mb-2.list-none class=(index.even? ? "bg-white" : "bg-gray-100") 
+            .border.border-gray-300.rounded-lg.p-4
+              .flex.items-center.justify-between
+                .talk-theme.text-lg.text-gray-800
+                  = talk_theme.theme
+                - if talk_theme.user_id == current_user.id
+                  = button_to '削除', event_talk_theme_path(@event, talk_theme), method: :delete, data: { confirm: '本当に削除しますか？' }, class: "ml-4 px-3 py-1 bg-red-500 text-white rounded-md hover:bg-red-600"

--- a/app/views/talk_themes/index.html.slim
+++ b/app/views/talk_themes/index.html.slim
@@ -1,0 +1,17 @@
+h1 トークテーマ一覧
+.talk-theme-form
+  = form_with(model: [@event, TalkTheme.new], local: true) do |f|
+    .add-theme
+      = f.label :theme, "トークテーマ名"
+      = f.text_field :theme
+    = f.submit "追加"
+.talk-themes
+ ul
+  - @talk_themes.each do |talk_theme|
+    li
+      .talk-theme
+        = talk_theme.theme
+        - if talk_theme.user_id == current_user.id
+          = button_to '削除', event_talk_theme_path(@event, talk_theme), method: :delete, data: { confirm: '本当に削除しますか？' }
+          
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,9 @@ ja:
       create_sucsess: イベントが作成されました。
       update_sucsess: イベントを更新しました。
       request_deletion: 削除申請を受け付けました。確認次第、削除対応を行います。ありがとうございました。
+    talk_theme:
+      create_success: トークテーマが追加されました。
+      destroy_success: トークテーマが削除されました。
     attendance:
       create_success: 出席登録が完了しました。
       destroy_success: 出席を取り消しました。
@@ -21,6 +24,8 @@ ja:
       entry_failure: イベントへの参加登録に失敗しました。
       entry_cancel_failure: イベントへの参加取り消しに失敗しました。
       request_deletion_failure: 削除申請に失敗しました。
+    talk_theme:
+      not_participating: このイベントに参加していないため、トークテーマを登録できません。
     attendance:
       create_failure: 出席登録に失敗しました。
       destroy_failure: 出席取り消しに失敗しました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   delete 'log_out', to: 'sessions#destroy', as:'log_out'
   resources :users, only: [:show, :edit, :update ]
   resources :events, only: [:index, :show, :new, :create, :edit, :update] do
+    resources :talk_themes, only: [:index, :create, :destroy]
     resources :event_participants, only: [:create, :destroy]
     resources :attendances, only: [:create, :destroy]
 

--- a/test/controllers/talk_themes_controller_test.rb
+++ b/test/controllers/talk_themes_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TalkThemesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## issue・PR

- #34

## description

- トークテーマページを実装
イベントに紐づくトークテーマのページを追加
- トークテーマの登録/削除機能を実装
トークテーマの登録/削除ができるようになった
- 仮CSS適用
作業効率のためCSSを適用(後ほど修正予定)
