### PR TITLE
ダッシュボードに直近のイベントが正常に表示されるように修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,13 @@ class User < ApplicationRecord
 
   def upcoming_event
     event_ids = event_participants.pluck(:event_id)
-    Event.where(id: event_ids).where('start_time > ?', Time.current).order(:start_time).first
+    Event.where(id: event_ids).select do |event|
+      next_scheduled_with_time = event.next_scheduled_date.to_time.change(
+        hour: event.start_time.hour,
+        min: event.start_time.min
+      )
+      next_scheduled_with_time > Time.zone.now
+    end.min_by(&:next_scheduled_date)
   end
 
   def attendance_for(event)


### PR DESCRIPTION
## issue・PR

- #46 

## description

- upcoming_eventメソッドを修正
ユーザーが登録しているイベントの中から直近のイベントを取得するメソッドが機能していなかったため修正
